### PR TITLE
[lfs] Allow more common characters as comment prefixes

### DIFF
--- a/legendary/lfs/lgndry.py
+++ b/legendary/lfs/lgndry.py
@@ -47,7 +47,7 @@ class LGDLFS:
         self._overlay_update_info = None
         self._overlay_install_info = None
         # Config with game specific settings (e.g. start parameters, env variables)
-        self.config = LGDConf(comment_prefixes='/', allow_no_value=True)
+        self.config = LGDConf(comment_prefixes=(';', '#', '/'), allow_no_value=True)
 
         if config_file:
             # if user specified a valid relative/absolute path use that,


### PR DESCRIPTION
In addition to the `/` character, this also allows `;` and `#` to be used as comment prefix characters in `config.ini`.

Fixes #673