### PR TITLE
[lfs] Only check XDG_CONFIG_HOME when not on 'Windows'

### DIFF
--- a/legendary/lfs/lgndry.py
+++ b/legendary/lfs/lgndry.py
@@ -26,6 +26,10 @@ class LGDLFS:
     def __init__(self, config_file=None):
         self.log = logging.getLogger('LGDLFS')
 
+        # This can happen only when running in Wine under an OS using freedesktop
+        if os.name == 'nt' and os.environ.get('XDG_CONFIG_HOME', None):
+            del os.environ['XDG_CONFIG_HOME']
+
         if config_path := os.environ.get('LEGENDARY_CONFIG_PATH'):
             self.path = config_path
         elif config_path := os.environ.get('XDG_CONFIG_HOME'):

--- a/legendary/lfs/lgndry.py
+++ b/legendary/lfs/lgndry.py
@@ -23,6 +23,10 @@ class LGDLFS:
     def __init__(self, config_file=None):
         self.log = logging.getLogger('LGDLFS')
 
+        # This can happen only when running in Wine under an OS using freedesktop
+        if os.name == 'nt' and os.environ.get('XDG_CONFIG_HOME', None):
+            del os.environ['XDG_CONFIG_HOME']
+
         if config_path := os.environ.get('LEGENDARY_CONFIG_PATH'):
             self.path = config_path
         elif config_path := os.environ.get('XDG_CONFIG_HOME'):


### PR DESCRIPTION
When running legendary through Wine and `XDG_CONFIG_HOME` is set in the environment, `config_path` resolves to the absolute path to the Linux config directory. Wine in turn resolves the path in a way that Legendary uses the existing Linux host config directory instead of creating/using the one under Wine prefix in `%USERPROFILE%\.config`.
