### PR TITLE
[cli/core]: report grant date information with `info`

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -1734,7 +1734,7 @@ class LegendaryCLI:
             # list all owned DLC based on entitlements
             if entitlements and not game.is_dlc:
                 owned_entitlements = {i['entitlementName'] for i in entitlements}
-                owned_app_names = {g.app_name for g in self.core.get_assets(args.platform)}
+                owned_app_names = {g.app_name for g in self.core.get_assets(platform=args.platform)}
                 owned_dlc = []
                 for dlc in game.metadata.get('dlcItemList', []):
                     installable = dlc.get('releaseInfo', None)

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -1652,7 +1652,7 @@ class LegendaryCLI:
             args.offline = True
 
         manifest_data = None
-        entitlements = None
+        entitlements = []
         is_preloaded = False
         manifest_secrets = dict()
         # load installed manifest or URI
@@ -1669,7 +1669,7 @@ class LegendaryCLI:
             else:
                 logger.info('Game not installed and offline mode enabled, cannot load manifest.')
         elif game:
-            entitlements = self.core.egs.get_user_entitlements_full()
+            entitlements = self.core.lgd.entitlements if self.core.lgd.entitlements else []
             egl_meta = self.core.egs.get_game_info(game.namespace, game.catalog_item_id)
             game.metadata = egl_meta
             # Get manifest if asset exists for current platform
@@ -1683,6 +1683,10 @@ class LegendaryCLI:
                                        game.app_version(args.platform)))
             all_versions = {k: v.build_version for k, v in game.asset_infos.items()}
             game_infos.append(InfoItem('All versions', 'platform_versions', all_versions, all_versions))
+            # Grant date from entitlements
+            entitlement = next((ent for ent in entitlements if ent['namespace'] == game.namespace), None)
+            grant_date = entitlement["grantDate"] if entitlement else game.metadata["creationDate"]
+            game_infos.append(InfoItem('Grant date', 'grant_date', grant_date, grant_date))
             # Cloud save support for Mac and Windows
             game_infos.append(InfoItem('Cloud saves supported', 'cloud_saves_supported',
                                        game.supports_cloud_saves or game.supports_mac_cloud_saves,

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -2066,7 +2066,7 @@ class LegendaryCLI:
             redeemed = {k['gameId'] for k in key_list if k['redeemedOnUplay']}
 
             games = self.core.get_game_list()
-            entitlements = self.core.egs.get_user_entitlements_full()
+            entitlements = self.core.lgd.entitlements if self.core.lgd.entitlements else []
             owned_entitlements = {i['entitlementName'] for i in entitlements}
 
             uplay_games = []

--- a/legendary/core.py
+++ b/legendary/core.py
@@ -360,6 +360,11 @@ class LegendaryCore:
                 ]
             })
 
+            # only get entitlements if there was an asset update
+            if self.lgd.assets != assets or not self.lgd.entitlements:
+                self.log.info('Updating entitlements.')
+                self.lgd.entitlements = self.egs.get_user_entitlements_full()
+
             # only save (and write to disk) if there were changes
             if self.lgd.assets != assets:
                 self.lgd.assets = assets
@@ -498,10 +503,6 @@ class LegendaryCore:
                 _dlc[game.metadata['mainGameItem']['id']].append(game)
             elif not any(i['path'] == 'mods' for i in game.metadata.get('categories', [])) and platform in app_assets:
                 _ret.append(game)
-
-        if meta_updated:
-            self.log.info('Updating entitlements.')
-            self.lgd.entitlements = self.egs.get_user_entitlements_full()
 
         self.update_aliases(force=meta_updated)
         if meta_updated:

--- a/legendary/core.py
+++ b/legendary/core.py
@@ -499,6 +499,10 @@ class LegendaryCore:
             elif not any(i['path'] == 'mods' for i in game.metadata.get('categories', [])) and platform in app_assets:
                 _ret.append(game)
 
+        if meta_updated:
+            self.log.info('Updating entitlements.')
+            self.lgd.entitlements = self.egs.get_user_entitlements_full()
+
         self.update_aliases(force=meta_updated)
         if meta_updated:
             self._prune_metadata()


### PR DESCRIPTION
Entitlements are updated only when there is an asset update. If no matching entitlement is found, the creation date from the game's metadata is returned instead.
