### PR TITLE
Make `case_insensitive_file_search` a no-op on Windows

### DIFF
--- a/legendary/lfs/wine_helpers.py
+++ b/legendary/lfs/wine_helpers.py
@@ -1,6 +1,7 @@
 import configparser
 import logging
 import os
+import sys
 
 logger = logging.getLogger('WineHelpers')
 
@@ -23,8 +24,11 @@ def get_shell_folders(registry, wine_pfx):
 def case_insensitive_file_search(path: str) -> str:
     """
     Similar to case_insensitive_path_search: Finds a file case-insensitively
-    Note that this *does* work on Windows, although it's rather pointless
+    No-op on Windows
     """
+    if sys.platform == 'win32':
+        return path
+
     if os.path.exists(path):
         return path
 


### PR DESCRIPTION
`os.path.join('C:', 'foo')` does *not* give you an absolute path from `C:` (instead resulting in a path relative to the current working directory). This causes games to get installed to `<path to Legendary>\Users\<username>\...` if `C:\Users\<username>\...` is selected

Since we do not need to do extra work to be case-insensitive on Windows (it already is by default), we can just skip `case_insensitive_file_search` completely