### PR TITLE
[cli] Add --hidden flag to close console immediately on launch

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -738,7 +738,9 @@ class LegendaryCLI:
             if params.environment:
                 logger.debug('Environment overrides: {}'.format(', '.join(
                     f'{k}={v}' for k, v in params.environment.items())))
-            subprocess.Popen(full_params, cwd=params.working_directory, env=full_env, shell=os.name == 'nt')
+            subprocess.Popen(full_params, cwd=params.working_directory, env=full_env,
+                             shell=os.name == 'nt',
+                             creationflags=subprocess.CREATE_NO_WINDOW if os.name == 'nt' and args.hidden else 0)
 
     def _launch_third_party(self, args):
         game = self.core.get_game(app_name=args.app_name)
@@ -2917,6 +2919,8 @@ def main():
                                help='Launch Ubisoft to install and run the game.')
     launch_parser.add_argument('--json', dest='json', action='store_true',
                                help='Print launch information as JSON and exit')
+    launch_parser.add_argument('--hidden', dest='hidden', action='store_true',
+                               help='Hide the console for the launched game on Windows')
 
     if os.name != 'nt':
         launch_parser.add_argument('--wine', dest='wine_bin', action='store', metavar='<wine binary>',


### PR DESCRIPTION
#668 introduced `shell=True` for Windows game launches to fix UAC prompts:
```py
use_shell = False

if os.name == 'nt':
    use_shell = True
subprocess.Popen(full_params, cwd=params.working_directory, env=full_env, shell=use_shell)
```
Later got changed via #762 to just this:
```py
subprocess.Popen(full_params, cwd=params.working_directory, env=full_env, shell=os.name == 'nt')
```
#762 didn't change the behaviour, so it's the same `shell=True` either way.

This PR adds a new launch flag called `--hidden` that restores the old closing behaviour from 0.20.34 "Direct Intervention" and lower, while keeping the new default by just not using said flag.

This has been annoying me ever so slightly, and I also decided to change it to this flag considering a Discord message I have seen that talked about it as well, so I knew I wasn't alone on that:
<img width="903" height="152" alt="image" src="https://github.com/user-attachments/assets/e0162efe-cc7e-4391-ba94-ec4a74cb111c" />

As for #668 I have tested Once Human with both the --hidden flag set, and not set, and in both occasions it asked me for UAC as expected. 