### PR TITLE
ci: exclude dev dependencies from zipapp packaging

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -80,7 +80,7 @@ jobs:
     - run: mkdir -p build dist
 
     - name: Dependencies
-      run: uv export --format requirements.txt --no-editable | uv pip install --requirement - --target build
+      run: uv export --format requirements.txt --no-editable --no-dev | uv pip install --requirement - --target build
 
     - run: cp zipapp_main.py build/__main__.py
 


### PR DESCRIPTION
it looks like ruff binary was being installed, inflating the size by a lot