### PR TITLE
feat: support symlink

### DIFF
--- a/legendary/downloader/mp/manager.py
+++ b/legendary/downloader/mp/manager.py
@@ -344,6 +344,10 @@ class DLManager(Process):
             # skip unchanged and empty files
             if current_file.filename in mc.unchanged:
                 continue
+            elif current_file.symlink_target:
+                self.tasks.append(FileTask(current_file.filename, old_file=current_file.symlink_target,
+                                           flags=TaskFlags.CREATE_SYMLINK))
+                continue
             elif not current_file.chunk_parts:
                 self.tasks.append(FileTask(current_file.filename, flags=TaskFlags.CREATE_EMPTY_FILE))
                 continue

--- a/legendary/downloader/mp/workers.py
+++ b/legendary/downloader/mp/workers.py
@@ -207,6 +207,29 @@ class FileWorker(Process):
                     open(full_path, 'a').close()
                     self.o_q.put(WriterTaskResult(success=True, **j.__dict__))
                     continue
+                if j.flags & TaskFlags.CREATE_SYMLINK:
+                    if current_file:
+                        logger.warning('Trying to create symlink without closing first!')
+                        current_file.close()
+                        current_file = None
+
+                    try:
+                        os.symlink(j.old_file, full_path)
+                    except FileExistsError:
+                        try:
+                            os.remove(full_path)
+                            os.symlink(j.old_file, full_path)
+                        except OSError as e:
+                            logger.error(f'Creating symlink failed: {e!r}')
+                            self.o_q.put(WriterTaskResult(success=False, **j.__dict__))
+                            continue
+                    except OSError as e:
+                        logger.error(f'Creating symlink failed: {e!r}')
+                        self.o_q.put(WriterTaskResult(success=False, **j.__dict__))
+                        continue
+
+                    self.o_q.put(WriterTaskResult(success=True, **j.__dict__))
+                    continue
                 elif j.flags & TaskFlags.OPEN_FILE:
                     if current_file:
                         logger.warning(f'Opening new file {j.filename} without closing previous! {last_filename}')

--- a/legendary/models/downloading.py
+++ b/legendary/models/downloading.py
@@ -59,6 +59,7 @@ class TaskFlags(Flag):
     CLOSE_FILE = auto()
     DELETE_FILE = auto()
     CREATE_EMPTY_FILE = auto()
+    CREATE_SYMLINK = auto()
     RENAME_FILE = auto()
     RELEASE_MEMORY = auto()
     MAKE_EXECUTABLE = auto()


### PR DESCRIPTION
fixed to create symlinks instead of empty files.

for macOS compatible games, bundled frameworks sometimes use symlinks. for example, Google Breakpad has a structure like this:
```
Breakpad.framework
├─ Breakpad -> Versions/Current/Breakpad
├─ Resources -> Versions/Current/Resources
└─ Versions
   ├─ A/
   │  ├─ Breakpad
   │  ├─ Resources/
   │  │  └─ ...
   │  └─ _CodeSignature/
   └─ Current -> A
```

If symlinks are treated as empty files, the game will fail to launch.