### PR TITLE
Pick up newly required install tags on update

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -973,6 +973,14 @@ class LegendaryCLI:
                     logger.error(f'Unable to get SDL data for {sdl_name}')
             else:
                 args.install_tag = config_tags.split(',')
+                # config tags are from install time, Epic may have added required tags since then
+                sdl_data = self.core.get_sdl_data(sdl_name, platform=args.platform)
+                if sdl_data and '__required' in sdl_data:
+                    new_tags = [t for t in sdl_data['__required']['tags'] if t not in args.install_tag]
+                    if new_tags:
+                        logger.info(f'Adding new required install tags: {", ".join(t for t in new_tags if t)}')
+                        args.install_tag.extend(new_tags)
+                        self.core.lgd.config.set(game.app_name, 'install_tags', ','.join(args.install_tag))
         elif args.install_tag and not game.is_dlc and not args.no_install:
             config_tags = ','.join(args.install_tag)
             logger.info(f'Saving install tags for "{game.app_name}" to config: {config_tags}')


### PR DESCRIPTION
Install tags get written to config on first install and never looked at again
(cli.py:962). If Epic adds a required tag later, existing installs never get it,
and the next update deletes the files for it since they're no longer in the
stored list. verify filters by that same list so it reports the install as fine.

On Fortnite this loses pakchunk100iad-WindowsClient.uondemandtoc (tagged only
GFP_BRCosmeticsInstallOnDemand) and pakchunk29-WindowsClient (FatCosmo), so
gliders and cosmetics stop loading. --reset-sdl is the only way out right now,
which lines up with #725.

This fetches the SDL data on update too and adds any required tags that are
missing. Only adds, so optional packs you deselected are left alone.

Tested against an install that had the problem - the patch flagged exactly the
15 files (186 MiB) that turned out to be the fix.

Ref #711 - this would fix #711 for anyone whose stored tags predate these tags being added. a fresh install today already picks them up