### PR TITLE
fix: Parse global options no matter where they are in the command

### DIFF
--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -2721,22 +2721,24 @@ def main():
     if not stdout.isatty():
         stdout.reconfigure(encoding='utf-8')
 
-    parser = argparse.ArgumentParser(description=f'Legendary v{__version__} - "{__codename__}"')
-    parser.register('action', 'parsers', HiddenAliasSubparsersAction)
+    global_parser = argparse.ArgumentParser(add_help=False)
 
     # general arguments
-    parser.add_argument('-H', '--full-help', dest='full_help', action='store_true',
-                        help='Show full help (including individual command help)')
-    parser.add_argument('-v', '--debug', dest='debug', action='store_true', help='Set loglevel to debug')
-    parser.add_argument('-y', '--yes', dest='yes', action='store_true', help='Default to yes for all prompts')
-    parser.add_argument('-V', '--version', dest='version', action='store_true', help='Print version and exit')
-    parser.add_argument('-c', '--config-file', dest='config_file', action='store', metavar='<path/name>',
-                        help=argparse.SUPPRESS)
-    parser.add_argument('-J', '--pretty-json', dest='pretty_json', action='store_true',
-                        help='Pretty-print JSON')
-    parser.add_argument('-A', '--api-timeout', dest='api_timeout', action='store',
-                        type=float, default=10, metavar='<seconds>',
-                        help='API HTTP request timeout (default: 10 seconds)')
+    global_parser.add_argument('-H', '--full-help', dest='full_help', action='store_true',
+                               help='Show full help (including individual command help)')
+    global_parser.add_argument('-v', '--debug', dest='debug', action='store_true', help='Set loglevel to debug')
+    global_parser.add_argument('-y', '--yes', dest='yes', action='store_true', help='Default to yes for all prompts')
+    global_parser.add_argument('-V', '--version', dest='version', action='store_true', help='Print version and exit')
+    global_parser.add_argument('-c', '--config-file', dest='config_file', action='store', metavar='<path/name>',
+                               help=argparse.SUPPRESS)
+    global_parser.add_argument('-J', '--pretty-json', dest='pretty_json', action='store_true',
+                               help='Pretty-print JSON')
+    global_parser.add_argument('-A', '--api-timeout', dest='api_timeout', action='store',
+                               type=float, default=10, metavar='<seconds>',
+                               help='API HTTP request timeout (default: 10 seconds)')
+
+    parser = argparse.ArgumentParser(description=f'Legendary v{__version__} - "{__codename__}"', parents=[global_parser])
+    parser.register('action', 'parsers', HiddenAliasSubparsersAction)
 
     # all the commands
     subparsers = parser.add_subparsers(title='Commands', dest='subparser_name', metavar='<command>')
@@ -3112,6 +3114,20 @@ def main():
                                      help='Output information in JSON format')
 
     args, extra = parser.parse_known_args()
+
+    # Reparse global parser options if there are unrecognized args
+    # argparse only uses one parser at once, so as soon as it encounters a subparser, the global options can no longer
+    # be set and are silently ignored. Consider something like `legendary list --api-timeout 20` for example, the
+    # subparser does not have a `--api-timeout` option, so it ends up in `extra` (even though it should be in the global
+    # args)
+    if extra:
+        # Remove all default values, otherwise they will overwrite the options the first pass set
+        for action in global_parser._actions:
+            action.default = argparse.SUPPRESS
+
+        global_args, extra = global_parser.parse_known_args(extra)
+        for key, value in global_args.__dict__.items():
+            setattr(args, key, value)
 
     if args.version:
         print(f'legendary version "{__version__}", codename "{__codename__}"')

--- a/legendary/cli.py
+++ b/legendary/cli.py
@@ -3129,6 +3129,10 @@ def main():
         for key, value in global_args.__dict__.items():
             setattr(args, key, value)
 
+    # Don't pass along the literal "--" if it is added to signal the end of Legendary's arguments
+    if extra and extra[0] == '--':
+        extra.pop(0)
+
     if args.version:
         print(f'legendary version "{__version__}", codename "{__codename__}"')
         exit(0)


### PR DESCRIPTION
Noticed this while working on https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/5726

Depending on where a global argument is in the command, it will get parsed differently (or rather, not at all):

```shell
$ legendary list --third-party --api-timeout 240
Namespace(full_help=False, debug=False, yes=False, version=False, config_file=None, pretty_json=False, api_timeout=10, subparser_name='list', platform=None, include_ue=False, include_noasset=True, csv=False, tsv=False, json=False, force_refresh=False)

$ legendary --api-timeout 240 list --third-party                  
Namespace(full_help=False, debug=False, yes=False, version=False, config_file=None, pretty_json=False, api_timeout=240.0, subparser_name='list', platform=None, include_ue=False, include_noasset=True, csv=False, tsv=False, json=False, force_refresh=False)
```

(this is with a test version that just prints out `args` and exits)

I don't think this is how arguments should work.

The "unknown" argument ends up in `extra`, so we can catch it by checking if `extra` has entries, and if so, parsing those entries again using a parser that only has the global options (and no default options for those). This resolves the issue:

```shell
$ legendary --api-timeout 240 list --third-party    
Namespace(full_help=False, debug=False, yes=False, version=False, config_file=None, pretty_json=False, api_timeout=240.0, subparser_name='list', platform=None, include_ue=False, include_noasset=True, csv=False, tsv=False, json=False, force_refresh=False)

$ legendary list --api-timeout 240 --third-party 
Namespace(full_help=False, debug=False, yes=False, version=False, config_file=None, pretty_json=False, api_timeout=240.0, subparser_name='list', platform=None, include_ue=False, include_noasset=True, csv=False, tsv=False, json=False, force_refresh=False)

# This command might seem strange, but it demonstrates the necessity of the default value suppression. If we would not do it, `api_timeout` would end up with its default value again
$ legendary --api-timeout 240 list --third-party foo
Namespace(full_help=False, debug=False, yes=False, version=False, config_file=None, pretty_json=False, api_timeout=240.0, subparser_name='list', platform=None, include_ue=False, include_noasset=True, csv=False, tsv=False, json=False, force_refresh=False)
```